### PR TITLE
Working local publish & dry-run w/ lerna

### DIFF
--- a/support/cli/publish.ts
+++ b/support/cli/publish.ts
@@ -1,0 +1,32 @@
+import * as yargs from 'yargs';
+import { publish } from '../publish';
+
+interface Arguments {
+	dryRun: boolean;
+	forcePublish: string;
+	pushGit: boolean;
+	skipTest: boolean;
+	releaseVersion: string;
+}
+
+const yargsDefinition = {
+	'dry-run': {
+		boolean: true,
+		describe: 'do not publish to NPM or push git'
+	},
+	'skip-test': {
+		boolean: true,
+		describe: 'skip running tests as part of the release'
+	},
+	'release-version': {
+		string: true,
+		describe: 'release version'
+	},
+	'push-git': {
+		boolean: true,
+		describe: 'automatically push to git after npm publish'
+	}
+};
+
+const argv: Arguments = yargs.option(yargsDefinition).argv as any;
+publish(argv);

--- a/support/localnpm/README.md
+++ b/support/localnpm/README.md
@@ -1,0 +1,52 @@
+# Local NPM repository
+
+A local NPM repository is used to test publish scripts against an actual repository. A Nexus docker container allows
+ a production-like test environment to which monorepo projects can be published.
+ 
+## Running Nexus
+
+Nexus runs in a docker container using docker-compose. It requires that both docker and docker-compose are
+ installed on the host system.
+ 
+Start the Nexus container:
+
+`docker-compose up`
+
+Connect to the repository:
+
+[http://localhost:8081](http://localhost:8081)
+
+Credentials
+
+* *Username*: admin
+* *Password*: admin123
+
+For more information on the Nexus docker image visit [sonatype/nexus](https://hub.docker.com/r/sonatype/nexus/) in 
+ the docker hub.
+
+## Publishing to local Nexus
+
+First, make sure you've created an npm registry. Follow 
+ [these directions](https://blog.sonatype.com/using-nexus-3-as-your-repository-part-2-npm-packages)
+ to create a local npm registry.
+
+In brief, you will
+
+* Sign in as admin
+* Create a new npm (hosted) repository (name it `test`)
+* Go to realms and add `npm Bearer Token Realm` (login wont work otherwise)
+
+Then login -- in this example we created a registry named `test`
+
+`npm login --registry "npm login --registry "http://localhost:8081/repository/test/"`
+
+Publishing to a local registry can be done by passing registry properties to npm.
+
+`npm run pub -- --registry http://localhost:8081/repository/test/`
+
+You can force lerna to publish a specific package, even it it has not been changed by using `force-publish`.
+ 
+ `npm run pub -- --registry http://localhost:8081/repository/test/ --force-publish=\@dojo/core`
+
+This will run the publish script against only `@dojo/core` and publish it to npm regardless of whether it's been 
+ updated.

--- a/support/localnpm/docker-compose.yml
+++ b/support/localnpm/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  localnexus:
+    image: sonatype/nexus3
+    ports:
+      - "8081:8081"

--- a/support/publish.ts
+++ b/support/publish.ts
@@ -1,0 +1,238 @@
+import { join, resolve } from 'path';
+import { awaitProcess, isProcessError, runAsPromise, spawnCommand } from './utils/process';
+import { prepackage } from './prepackage';
+import Set from '../packages/shim/src/Set';
+
+const binDir = join(__dirname, '..', 'node_modules', '.bin');
+const packageDir = join(__dirname, '..', 'packages');
+const lernaBin = resolve(binDir, 'lerna');
+
+interface Updated {
+	name: string;
+	version: string;
+	private: boolean;
+}
+
+const runToTerminalOptions = Object.freeze({
+	stdio: [ null, process.stdout, process.stdin ]
+});
+
+export interface Options {
+	dryRun: boolean;
+	forcePublish: string;
+	pushGit: boolean;
+	releaseVersion: string;
+	skipTest: boolean;
+}
+
+/**
+ * Publish flow
+ */
+export async function publish(options: Options) {
+	const doGitPush = options.pushGit && !options.dryRun;
+
+	try {
+		const updatedPackages = await (options.forcePublish ? getPackages(options.forcePublish) : getUpdatedPackages());
+
+		if (!updatedPackages.length) {
+			console.log("No packages to publish.");
+			process.exitCode = 1;
+			return;
+		}
+
+		// TODO add check to see if they're logged in to npm before we do this long process
+		await lernaPublish(options);
+
+		const releaseVersion = assertReleaseVersion(updatedPackages);
+		if (!options.dryRun) {
+			await assertGitTag(`v${ releaseVersion }`);
+		}
+		await buildDist(updatedPackages, options.skipTest);
+		for (let { name } of updatedPackages) {
+			await prepackage(getPackageDirectory(name));
+		}
+		if (options.dryRun) {
+			await buildArtifacts(updatedPackages);
+		}
+		else {
+			await release(updatedPackages, releaseVersion, options);
+			if (doGitPush) {
+				await pushGit();
+			}
+		}
+		printSummary(updatedPackages, options, releaseVersion);
+	}
+	catch(e) {
+		console.log('error', e);
+		throw e;
+	}
+}
+
+function printSummary(packs: Updated[], options: Options, version: string) {
+	console.log('You did great. Just the best. <3');
+	if (options.dryRun) {
+		console.log(`You did a dry run of ${ packs.length } packages:`);
+	}
+	else {
+		console.log(`You published ${ packs.length } packages at v${ version }:`);
+	}
+	for (let pack of packs) {
+		console.log(pack.name);
+	}
+	console.log(' ');
+	if (!options.dryRun && !options.pushGit) {
+		console.log(`Don't forget to push to git`);
+		console.log('git push');
+		console.log('git push tags');
+	}
+}
+
+async function getPackages(packageList: string): Promise<Updated[]> {
+	const result = (await runAsPromise(lernaBin, [ 'ls', '--json'])).getOutput();
+	const allPackages: Updated[] = JSON.parse(result);
+
+	if (packageList === '*') {
+		return allPackages;
+	}
+
+	const packageNames = new Set(packageList.split(','));
+	return allPackages.filter(pack => packageNames.has(pack.name));
+}
+
+async function getUpdatedPackages(): Promise<Updated[]> {
+	try {
+		const updatedPackagesResult = (await runAsPromise(lernaBin, [ 'updated', '--json'])).getOutput();
+		return JSON.parse(updatedPackagesResult);
+	}
+	catch (e) {
+		if (isProcessError(e)) {
+			// lerna returns a code of `1` if there's no packages to be updated.
+			if (e.stdErr.indexOf('No packages need updating')) {
+				return [];
+			}
+		}
+		throw e;
+	}
+}
+
+function getPackageDirectory(packageName: string) {
+	return packageName.substr(packageName.indexOf('/'));
+}
+
+/**
+ * Asserts that all package versions match
+ * @return the release version
+ */
+function assertReleaseVersion(updatedPackages: Updated[]): string {
+	const versions = updatedPackages.map((pack) => {
+		const name = getPackageDirectory(pack.name);
+		const packageJsonPath = join(packageDir, name, 'package.json');
+		const packagejson = require(packageJsonPath);
+		return packagejson.version;
+	});
+
+	const releaseVersion = versions[0];
+	for (let version of versions) {
+		if (version !== releaseVersion) {
+			throw new Error(`Version mismatch. Expected ${ releaseVersion }. Saw ${ version }.`);
+		}
+	}
+	return releaseVersion;
+}
+
+/**
+ * Resolves a promise if the provided git tag exists locally
+ */
+function assertGitTag(tag: string) {
+	return runAsPromise('git', [ 'describe', '--tags', tag ], runToTerminalOptions);
+}
+
+/**
+ * Use lerna to publish a new release
+ *
+ * 1. Prompts the user for a version
+ * 2. Updates package.json version
+ * 3. Creates a git commit (if not a dry run)
+ * 4. tags the commit (if not a dry run)
+ */
+async function lernaPublish(options: Options) {
+	const { releaseVersion, dryRun } = options;
+
+	const passthru = getPassthruOptions(['force-publish'], options);
+	const args = [ 'publish', '--skip-npm', '--message', '"Release %s"', ... passthru];
+	if (releaseVersion) {
+		args.push(`--repo-version=${ releaseVersion }`);
+	}
+	if (dryRun) {
+		args.push('--skip-git');
+	}
+
+	const command = spawnCommand(lernaBin, args, {
+		stdio: [ process.stdin, process.stdout, process.stderr ]
+	});
+
+	return await awaitProcess(command);
+}
+
+function getPassthruOptions(allowed: String[], options: object): string[] {
+	const args: string[] = [];
+	const passthruOptions = new Set(allowed);
+	for (let key in options) {
+		if (passthruOptions.has(key)) {
+			args.push(`--${ key }`, String((<any> options)[key]));
+		}
+	}
+	return args;
+}
+
+/**
+ * Builds all of the packages to be published
+ */
+async function buildDist(packages: Updated[], skipTest: boolean = false) {
+	const scope = packages.map(pack => pack.name).join('|');
+	// TODO it would be nice to also build and test upstream dependencies
+	await runAsPromise(lernaBin, [ 'run', 'clean', '--scope', scope], runToTerminalOptions);
+	if (!skipTest) {
+		await runAsPromise(lernaBin, [ 'run', 'test', '--scope', scope], runToTerminalOptions);
+	}
+	await runAsPromise(lernaBin, [ 'run', 'dist', '--scope', scope], runToTerminalOptions);
+}
+
+/**
+ * Builds artifacts of the updated packages
+ */
+async function buildArtifacts(updatedPackages: Updated[]) {
+	for (let { name } of updatedPackages) {
+		const destination = join(packageDir, getPackageDirectory(name), 'dist');
+		const sourcePath = join(packageDir, getPackageDirectory(name), 'dist', 'release');
+		console.log(`Building artifact in ${ sourcePath }`);
+		await runAsPromise('npm', [ 'pack', sourcePath ], {
+			cwd: destination,
+			... runToTerminalOptions
+		});
+	}
+}
+
+/**
+ * Publishes to npm
+ *
+ * TODO make more robust like https://github.com/dojo/scripts/blob/master/src/release.ts
+ * TODO test release against a private repository
+ */
+async function release(updatedPackages: Updated[], releaseVersion: string, options: Options) {
+	const passthru = getPassthruOptions(['registry'], options);
+	for (let { name } of updatedPackages) {
+		const sourcePath = join(packageDir, getPackageDirectory(name), 'dist', 'release');
+		const args = ['publish', sourcePath, '--access', 'public', ... passthru];
+
+		console.log(`Publishing artifact in ${ sourcePath }`);
+		await runAsPromise('npm', args, {
+			... runToTerminalOptions
+		});
+	}
+}
+
+async function pushGit() {
+	await runAsPromise('git', [ 'push' ], runToTerminalOptions);
+	await runAsPromise('git', [ 'push', '--tags' ], runToTerminalOptions);
+}

--- a/support/utils/process.ts
+++ b/support/utils/process.ts
@@ -1,0 +1,83 @@
+import { spawn, ChildProcess } from 'child_process';
+
+export class ProcessError extends Error {
+	constructor(
+		public readonly code: number,
+		public readonly stdErr = '',
+		public readonly stdOut = ''
+	) {
+		super(`Error exit code ${ code }`);
+	}
+}
+
+export function isProcessError(value: any): value is ProcessError {
+	return typeof value === "object" && value.stdErr != null && value.stdOut != null && value.hasOwnProperty('code');
+}
+
+export function spawnCommand(command: string, args: string[], options: any = {}): ChildProcess {
+	return spawn(command, args, {
+		shell: true,
+		... options
+	});
+}
+
+export async function awaitProcess(childProcess: ChildProcess) {
+	return new Promise<number>((resolve, reject) => {
+		childProcess.once('close', (code: number) => {
+			if (code <= 0) {
+				resolve(code);
+			}
+			else {
+				reject(new ProcessError(code));
+			}
+		});
+	});
+}
+
+export function collectOutput(childProcess: ChildProcess) {
+	let stderr = '';
+	let stdout = '';
+
+	if (childProcess.stdout) {
+		childProcess.stdout.setEncoding('utf8');
+		childProcess.stdout.on('data', (chunk) => {
+			stdout += chunk;
+		});
+	}
+
+	if (childProcess.stderr) {
+		childProcess.stderr.setEncoding('utf8');
+		childProcess.stderr.on('data', (chunk) => {
+			stderr += chunk;
+		});
+
+	}
+
+	return {
+		getOutput() {
+			return stdout;
+		},
+		getError() {
+			return stderr;
+		}
+	}
+}
+
+export async function runAsPromise(command: string, args: string[], options: any = {}) {
+	const process = spawnCommand(command, args, options);
+	const output = collectOutput(process);
+	let code: number;
+
+	try {
+		code = await awaitProcess(process);
+	}
+	catch (e) {
+		const code = 'code' in e ? e.code : 1;
+		throw new ProcessError(code, output.getError(), output.getOutput());
+	}
+
+	return {
+		code,
+		... output
+	};
+}


### PR DESCRIPTION
Resolves #3 using Lerna.

Cleaned up what I had and put forth a script for local publish. If/when we decide to use Rush or another monorepo solution this should give us a baseline feature set and a means of testing against a local npm repository.

<img width="760" alt="screen shot 2018-06-30 at 5 41 29 pm" src="https://user-images.githubusercontent.com/331431/42130097-d1b6557e-7c8d-11e8-943d-e729beb4e705.png">
